### PR TITLE
refactor: Remove unnecessary async/await

### DIFF
--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -85,7 +85,7 @@ function templateReplace(arn, action, resource_mapping_sub) {
     return arnReplace(arn, action, resource_mapping_sub, null);
 }
 
-async function getTemplates(action, iam_def) {
+function getTemplates(action, iam_def) {
     let action_parts = action['action'].split(":");
     let ret = '*';
     let original_templates = [];
@@ -131,7 +131,7 @@ async function getTemplates(action, iam_def) {
     return ret;
 }
 
-async function getUsedBy(privilege, sdk_map) {
+function getUsedBy(privilege, sdk_map) {
     let used_by_methods = [];
 
     for (let iam_mapping_name of Object.keys(sdk_map['sdk_method_iam_mappings']).sort()) {
@@ -766,7 +766,7 @@ async function processReferencePage() {
             access_class = "tx-color-03";
         }
 
-        let used_by = await getUsedBy(service['prefix'] + ':' + privilege['privilege'], sdk_map);
+        let used_by = getUsedBy(service['prefix'] + ':' + privilege['privilege'], sdk_map);
 
         if (privilege['description'].substr(privilege['description'].length-1) != "." && privilege['description'].length > 1) {
             privilege['description'] += ".";
@@ -815,7 +815,7 @@ async function processReferencePage() {
             let rowspan = sdk_map['sdk_method_iam_mappings'][iam_mapping_name].length + 1;
 
             let actionlink = "/iam/" + first_action['action'].split(":")[0] + "#" + first_action['action'].replace(":", "-");
-            let template = await getTemplates(first_action, iam_def_duplicate);
+            let template = getTemplates(first_action, iam_def_duplicate);
             let undocumented = '';
             if (first_action['undocumented']) {
                 undocumented = ' <span class="badge badge-danger">undocumented</span>';
@@ -830,7 +830,7 @@ async function processReferencePage() {
 
             for (let action of sdk_map['sdk_method_iam_mappings'][iam_mapping_name]) {
                 let actionlink = "/iam/" + action['action'].split(":")[0] + "#" + action['action'].replace(":", "-");
-                let template = await getTemplates(action, iam_def_duplicate);
+                let template = getTemplates(action, iam_def_duplicate);
                 let undocumented = '';
                 if (action['undocumented']) {
                     undocumented = ' <span class="badge badge-danger">undocumented</span>';
@@ -885,7 +885,7 @@ async function processReferencePage() {
                         access_class = "tx-color-03";
                     }
 
-                    let used_by = await getUsedBy(service['prefix'] + ':' + privilege['privilege'], sdk_map);
+                    let used_by = getUsedBy(service['prefix'] + ':' + privilege['privilege'], sdk_map);
 
                     if (privilege['description'].substr(privilege['description'].length-1) != "." && privilege['description'].length > 1) {
                         privilege['description'] += ".";


### PR DESCRIPTION
I've noticed that two functions can be non-`async` since no `await` is used.

Tested those functions works without `async`:


`getTemplates`
<img width="496" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/bf241cd7-dec9-4b69-a36c-ff29f1bb21b7">

`getUsedBy`
<img width="255" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/34baf94e-4d94-45ce-8472-246ab5417475">
