### PR TITLE
feat: Make content wider when screen is wide

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       </div><!-- content-header -->
 
       <div class="content-body" id="body-permissions" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">
@@ -264,7 +264,7 @@
       </div>
 
       <div class="content-body" id="body-bytag" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">
@@ -339,7 +339,7 @@
       </div>
 
       <div class="content-body" id="body-dashboard" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">
@@ -449,7 +449,7 @@
       </div>
 
       <div class="content-body" id="body-usage" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">
@@ -607,7 +607,7 @@
       </div>
 
       <div class="content-body" id="body-managedpolicies" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">
@@ -676,7 +676,7 @@
       </div>
 
       <div class="content-body" id="body-managedpolicy" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">
@@ -757,7 +757,7 @@
       </div>
 
       <div class="content-body" id="body-policyevaluator" style="display: none;">
-        <div class="container pd-x-0">
+        <div class="container-fluid pd-x-0">
           <div class="d-sm-flex align-items-center justify-content-between mg-b-20 mg-lg-b-25 mg-xl-b-30">
             <div>
               <nav aria-label="breadcrumb">


### PR DESCRIPTION
Closes #1

`container-fluid` removed max-width so the content can be wider when the screen is wide.
When the screen is narrow, it behaves like `container`.

Page | Before (capped with max-width) | After (fluid)
---|---|---
Dashboard | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/a43f14a5-1c6f-404e-8d38-d5f1b43b5a50) | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/00a09530-85e5-4d14-b3c0-b9f5f3e7f884)
Usage | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/06746415-007f-4588-ba97-8407767e3f79) | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/d80ea18c-0d43-4ad2-a897-00ceb3be3276)
ManagedPolicies | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/bbed8fd7-f38a-4d68-9b52-f6aa6f3be03b) | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/d34da847-5067-42b2-a843-ee7a963501d5)
Policy Evaluator | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/4ab97ff0-bba3-4ae6-ba94-2ad15602d371) | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/526f21a8-88a5-4592-abaf-a6e99de87f70)
Service (IAM tag) | ![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/e6df452b-0f85-4565-b7e7-5928e6efd756) |![image](https://github.com/iann0036/aws.permissions.cloud/assets/127635/227dbd15-4c8d-438e-995b-6ed738640bdd)
 



