### PR TITLE
feat: Better handling NotAction in Policy Evaluator

### DIFF
--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -243,7 +243,7 @@ function processCustomPolicy(iam_def, tags) {
                             // AWS Backup's recoveryPoint is the only one that has this pattern.
                             .replace("${Vendor}",service['prefix'])
                             .replace(/\*/g, "[^:]+")
-                            .replace(/\$\{[^}]+}/g, "[^:/]+"));
+                            .replace(/\$\{[^}]+}/g, "[^:/]+"), "i");
                 });
                 actionToArnPattern[service['prefix'] + ":" + privilege['privilege']] = privilege['resource_types']
                     .filter(rt => rt['resource_type'] !== "")
@@ -260,6 +260,16 @@ function processCustomPolicy(iam_def, tags) {
         var unknown_actions = []
 
         policy_json['Statement'].forEach(statement => {
+            let resources;
+            if (typeof statement['Resource'] === "string") {
+                resources = [statement['Resource']]
+            } else if (Array.isArray(statement['Resource'])) {
+                resources = statement['Resource'];
+            } else {
+                // No resource specified or invalid type
+                resources = ["*"];
+            }
+            const noWildcard = !resources.includes("*");
             if (statement['Action'] && statement['Effect'] == "Allow") {
                 if (!Array.isArray(statement['Action'])) {
                     statement['Action'] = [statement['Action']];
@@ -271,6 +281,14 @@ function processCustomPolicy(iam_def, tags) {
                         var re = new RegExp(matchexpression.toLowerCase());
                         if (potentialaction.toLowerCase().match(re)) {
                             foundmatch = true;
+
+                            const resourceArnPatterns = actionToArnPattern[potentialaction];
+                            if (noWildcard && $('#custompolicy-considerarn').is(':checked')) {
+                                if (resourceArnPatterns.every(pattern => resources.every(res => !pattern.test(res)))) {
+                                    // Skip addition if all of ARN patterns do not match any of the given Resource pattern
+                                    return;
+                                }
+                            }
                             
                             var condition = null;
                             if (statement['Condition']) {
@@ -322,16 +340,6 @@ function processCustomPolicy(iam_def, tags) {
                 if (!Array.isArray(statement['NotAction'])) {
                     statement['NotAction'] = [statement['NotAction']];
                 }
-                let resources;
-                if (typeof statement['Resource'] === "string") {
-                    resources = [statement['Resource']]
-                } else if (Array.isArray(statement['Resource'])) {
-                    resources = statement['Resource'];
-                } else {
-                    // No resource specified or invalid type
-                    resources = ["*"];
-                }
-                const noWildcard = !resources.includes("*");
                 Object.keys(allactions).forEach(potentialaction => {
                     var matched = false;
                     statement['NotAction'].forEach(action => {
@@ -345,7 +353,7 @@ function processCustomPolicy(iam_def, tags) {
                         return;
                     }
                     const resourceArnPatterns = actionToArnPattern[potentialaction];
-                    if (noWildcard) {
+                    if (noWildcard && $('#custompolicy-considerarn').is(':checked')) {
                         if (resourceArnPatterns.every(pattern => resources.every(res => !pattern.test(res)))) {
                             // Remove if all of ARN patterns do not match any of the given Resource pattern
                             return;

--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -231,9 +231,23 @@ function processCustomPolicy(iam_def, tags) {
         policy_json = JSON.parse($('.custompolicy').val());
 
         var allactions = {}
+        const actionToArnPattern = {}
         iam_def.forEach(service => {
             service['privileges'].forEach(privilege => {
                 allactions[service['prefix'] + ":" + privilege['privilege']] = privilege['access_level']
+
+                const resourceNameToArnPattern = {};
+                service['resources'].forEach(res => {
+                    resourceNameToArnPattern[res['resource']] = new RegExp(
+                        res['arn']
+                            // AWS Backup's recoveryPoint is the only one that has this pattern.
+                            .replace("${Vendor}",service['prefix'])
+                            .replace(/\*/g, "[^:]+")
+                            .replace(/\$\{[^}]+}/g, "[^:/]+"));
+                });
+                actionToArnPattern[service['prefix'] + ":" + privilege['privilege']] = privilege['resource_types']
+                    .filter(rt => rt['resource_type'] !== "")
+                    .map(rt => resourceNameToArnPattern[rt["resource_type"].replace("*", "")]);
             });
         });
 
@@ -308,6 +322,16 @@ function processCustomPolicy(iam_def, tags) {
                 if (!Array.isArray(statement['NotAction'])) {
                     statement['NotAction'] = [statement['NotAction']];
                 }
+                let resources;
+                if (typeof statement['Resource'] === "string") {
+                    resources = [statement['Resource']]
+                } else if (Array.isArray(statement['Resource'])) {
+                    resources = statement['Resource'];
+                } else {
+                    // No resource specified or invalid type
+                    resources = ["*"];
+                }
+                const noWildcard = !resources.includes("*");
                 Object.keys(allactions).forEach(potentialaction => {
                     var matched = false;
                     statement['NotAction'].forEach(action => {
@@ -319,6 +343,13 @@ function processCustomPolicy(iam_def, tags) {
                     });
                     if (matched) {
                         return;
+                    }
+                    const resourceArnPatterns = actionToArnPattern[potentialaction];
+                    if (noWildcard) {
+                        if (resourceArnPatterns.every(pattern => resources.every(res => !pattern.test(res)))) {
+                            // Remove if all of ARN patterns do not match any of the given Resource pattern
+                            return;
+                        }
                     }
 
                     var condition = null;


### PR DESCRIPTION
Closes #4

After this PR, `NotAction`-based IAM actions will be shown if they match any of the given `Resource`.

Resource matching are calculated from ARN patterns which is created from `resrouces[].arn` in https://github.com/iann0036/iam-dataset/blob/main/aws/iam_definition.json, e.g.:

```json
    "resources": [
      {
        "arn": "arn:${Partition}:lambda:${Region}:${Account}:code-signing-config:${CodeSigningConfigId}",
        "condition_keys": [],
        "resource": "code signing config"
      },
      {
        "arn": "arn:${Partition}:lambda:${Region}:${Account}:event-source-mapping:${UUID}",
        "condition_keys": [],
        "resource": "eventSourceMapping"
      },
      {
        "arn": "arn:${Partition}:lambda:${Region}:${Account}:layer:${LayerName}",
        "condition_keys": [],
        "resource": "layer"
      },
```

## Note

I've noticed that only AWS Backup has a special ARN pattern `arn:${Partition}:${Vendor}:${Region}:*:${ResourceType}:${RecoveryPointId}` that can math any resources.
I've tweaked it by replacing `${Vendor}` with service name (`backup` for this case).


## Test

<details>
<summary>Test case 1. Single resource, single NotAction</summary>

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Resource": [
        "arn:aws:lambda:us-west-2:012345678901:function:MyFunctionName*"
      ],
      "NotAction": [
        "lambda:Invoke*"
      ],
      "Effect": "Allow"
    }
  ]
}
```

this PR | AWS IAM Policy Creator
---|---
AddPermission | AddPermission
CreateAlias | CreateAlias
CreateFunction | CreateFunction
CreateFunctionUrlConfig | CreateFunctionUrlConfig
DeleteAlias | DeleteAlias
DeleteFunction | DeleteFunction
DeleteFunctionCodeSigningConfig | DeleteFunctionCodeSigningConfig
DeleteFunctionConcurrency | DeleteFunctionConcurrency
DeleteFunctionEventInvokeConfig | DeleteFunctionEventInvokeConfig
DeleteFunctionUrlConfig | DeleteFunctionUrlConfig
❌ missing in data source | DeleteProvisionedConcurrencyConfig
DisableReplication | DisableReplication
EnableReplication | EnableReplication
GetAlias | GetAlias
GetFunction | GetFunction
GetFunctionCodeSigningConfig | GetFunctionCodeSigningConfig
GetFunctionConcurrency | GetFunctionConcurrency
GetFunctionConfiguration | GetFunctionConfiguration
GetFunctionEventInvokeConfig | GetFunctionEventInvokeConfig
GetFunctionUrlConfig | GetFunctionUrlConfig
GetPolicy | GetPolicy
❌ missing in data source  | GetProvisionedConcurrencyConfig
GetRuntimeManagementConfig | GetRuntimeManagementConfig
ListAliases | ListAliases
ListFunctionEventInvokeConfigs | ListFunctionEventInvokeConfigs
ListFunctionUrlConfigs | ListFunctionUrlConfigs
ListProvisionedConcurrencyConfigs | ListProvisionedConcurrencyConfigs
ListTags | ListTags
ListVersionsByFunction | ListVersionsByFunction
PublishVersion | PublishVersion
PutFunctionCodeSigningConfig | PutFunctionCodeSigningConfig
PutFunctionConcurrency | PutFunctionConcurrency
PutFunctionEventInvokeConfig | PutFunctionEventInvokeConfig
❌ missing in data source  | PutProvisionedConcurrencyConfig
PutRuntimeManagementConfig | PutRuntimeManagementConfig
RemovePermission | RemovePermission
TagResource | TagResource
UntagResource | UntagResource
UpdateAlias | UpdateAlias
UpdateFunctionCode | UpdateFunctionCode
UpdateFunctionCodeSigningConfig | UpdateFunctionCodeSigningConfig
UpdateFunctionConfiguration | UpdateFunctionConfiguration
UpdateFunctionEventInvokeConfig | UpdateFunctionEventInvokeConfig
UpdateFunctionUrlConfig | UpdateFunctionUrlConfig

</details>

<details>
<summary>Test case 2. multiple resources, multiple NotActions</summary>


```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "NotAction": [
        "s3:Put*",
        "s3:*Bucket*",
        "s3:*Configuration*",
        "s3:Delete*",
        "s3:*ACL*",
        "s3:*Version*",
        "s3:*Replica*"
      ],
      "Resource": [
        "arn:aws:s3:::a-service-static",
        "arn:aws:s3:::a-service-static/*"
      ]
    }
  ]
}
```


this PR | AWS IAM Policy Creator
-- | --
s3:AbortMultipartUpload | AbortMultipartUpload
s3:BypassGovernanceRetention | BypassGovernanceRetention
s3:GetObject | GetObject
s3:GetObjectAttributes | GetObjectAttributes
s3:GetObjectLegalHold | GetObjectLegalHold
s3:GetObjectRetention | GetObjectRetention
s3:GetObjectTagging | GetObjectTagging
s3:GetObjectTorrent | GetObjectTorrent
s3:ListMultipartUploadParts | ListMultipartUploadParts
s3:RestoreObject | RestoreObject
ssm:SendCommand 🤔 | -  

`ssm:SendCommand` contains `resource_type: bucket` in iam-dataset.
That is the reason `ssm:SendCommand` appears in this PR.
However, I am not sure it is not listed in AWS IAM Policy Creator.
I guess it is a negligible difference. 
Not perfect, but better than now.
</details>
