### PR TITLE
cosmetic: Hide Chrome/WebKit's "x" button in search input

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -16,3 +16,10 @@
 .backdrop {
     z-index: 1100 !important;
 }
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+    -webkit-appearance:none;
+}


### PR DESCRIPTION
## Before
WebKit-based browsers (Chrome and Safari) shows `x` button in search input, which is confusing because it looks like the other `x` button to close search.
<img width="425" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/2a624c48-a6fd-40fb-bb49-8de8628de16e">
<img width="565" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/3f6c08bd-2cc8-4512-a023-487e5367f382">


## After
`x` button is no more shown.
<img width="430" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/41941acf-b7b7-4cf5-9c8e-ba54f59ff40a">
