### PR TITLE
optimize: Speed up /tag/ and /iam/ pages

### DIFF
--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -131,16 +131,22 @@ function getTemplates(action, iam_def) {
     return ret;
 }
 
+let privilege_2_iam_mapping_name = null;
 function getUsedBy(privilege, sdk_map) {
-    let used_by_methods = [];
-
-    for (let iam_mapping_name of Object.keys(sdk_map['sdk_method_iam_mappings']).sort()) {
-        for (let action of sdk_map['sdk_method_iam_mappings'][iam_mapping_name]) {
-            if (action['action'] == privilege) {
-                used_by_methods.push("<a href=\"/api/" + sdk_map['sdk_method_iam_mappings'][iam_mapping_name][0]['action'].split(":")[0] + "#" + iam_mapping_name.replace(".", "_") + "\">" + iam_mapping_name + "</a>");
+    if (privilege_2_iam_mapping_name === null) {
+        privilege_2_iam_mapping_name = {}
+        for (let iam_mapping_name of Object.keys(sdk_map['sdk_method_iam_mappings']).sort()) {
+            for (let action of sdk_map['sdk_method_iam_mappings'][iam_mapping_name]) {
+                if (privilege_2_iam_mapping_name[action['action']] == null) {
+                    privilege_2_iam_mapping_name[action['action']] = [];
+                }
+                privilege_2_iam_mapping_name[action['action']].push(iam_mapping_name)
             }
         }
     }
+    let used_by_methods = (privilege_2_iam_mapping_name[privilege] || []).map(iam_mapping_name => {
+        return "<a href=\"/api/" + sdk_map['sdk_method_iam_mappings'][iam_mapping_name][0]['action'].split(":")[0] + "#" + iam_mapping_name.replace(".", "_") + "\">" + iam_mapping_name + "</a>";
+    });
 
     if (used_by_methods.length) {
         used_by_methods = [...new Set(used_by_methods)]; // dedupe

--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -131,20 +131,20 @@ function getTemplates(action, iam_def) {
     return ret;
 }
 
-let privilege_2_iam_mapping_name = null;
+let privilege_to_iam_mapping_name = null;
 function getUsedBy(privilege, sdk_map) {
-    if (privilege_2_iam_mapping_name === null) {
-        privilege_2_iam_mapping_name = {}
+    if (privilege_to_iam_mapping_name === null) {
+        privilege_to_iam_mapping_name = {}
         for (let iam_mapping_name of Object.keys(sdk_map['sdk_method_iam_mappings']).sort()) {
             for (let action of sdk_map['sdk_method_iam_mappings'][iam_mapping_name]) {
-                if (privilege_2_iam_mapping_name[action['action']] == null) {
-                    privilege_2_iam_mapping_name[action['action']] = [];
+                if (privilege_to_iam_mapping_name[action['action']] == null) {
+                    privilege_to_iam_mapping_name[action['action']] = [];
                 }
-                privilege_2_iam_mapping_name[action['action']].push(iam_mapping_name)
+                privilege_to_iam_mapping_name[action['action']].push(iam_mapping_name)
             }
         }
     }
-    let used_by_methods = (privilege_2_iam_mapping_name[privilege] || []).map(iam_mapping_name => {
+    let used_by_methods = (privilege_to_iam_mapping_name[privilege] || []).map(iam_mapping_name => {
         return "<a href=\"/api/" + sdk_map['sdk_method_iam_mappings'][iam_mapping_name][0]['action'].split(":")[0] + "#" + iam_mapping_name.replace(".", "_") + "\">" + iam_mapping_name + "</a>";
     });
 


### PR DESCRIPTION
I found the `getUsedBy` function is compute-heavy since it iterates `sdk_map['sdk_method_iam_mappings']` many times.
By caching the `action`-to-`iam_mapping_name` mapping, `/tag/*` and `/iam/*` pages are now very fast.

Page | Before | After
---|--:|--:
https://aws.permissions.cloud/tag/aws:RequestTag/$%7BTagKey%7D | 10,768 ms | 11 ms
https://aws.permissions.cloud/iam/dynamodb | 487 ms | 10 ms
https://aws.permissions.cloud/iam/s3 | 860 ms | 10 ms
