### PR TITLE
fix: Uncaught type error on search in /iam/ and /api/

### DIFF
--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -879,9 +879,10 @@ async function processReferencePage() {
     for (let iam_mapping_name of Object.keys(sdk_map['sdk_method_iam_mappings']).sort()) {
         let iam_mapping_name_parts = iam_mapping_name.split(".");
         if (api_prefixes.includes(iam_mapping_name_parts[0])) {
-            let first_action = sdk_map['sdk_method_iam_mappings'][iam_mapping_name].shift();
+            let first_action = sdk_map['sdk_method_iam_mappings'][iam_mapping_name][0];
+            let other_actions =  sdk_map['sdk_method_iam_mappings'][iam_mapping_name].slice(1);
 
-            let rowspan = sdk_map['sdk_method_iam_mappings'][iam_mapping_name].length + 1;
+            let rowspan = other_actions.length + 1;
 
             let actionlink = "/iam/" + first_action['action'].split(":")[0] + "#" + first_action['action'].replace(":", "-");
             let template = getTemplates(first_action, iam_def_duplicate);
@@ -897,7 +898,7 @@ async function processReferencePage() {
                 <td class="tx-medium">' + template + '</td>\
             </tr>';
 
-            for (let action of sdk_map['sdk_method_iam_mappings'][iam_mapping_name]) {
+            for (let action of other_actions) {
                 let actionlink = "/iam/" + action['action'].split(":")[0] + "#" + action['action'].replace(":", "-");
                 let template = getTemplates(action, iam_def_duplicate);
                 let undocumented = '';


### PR DESCRIPTION
https://aws.permissions.cloud/iam/s3

If one searches the term that is the prefix for the service name of the page,  error "aws.permissions.cloud.js:716 Uncaught TypeError: Cannot read properties of undefined (reading 'action')" is raised.
See 716th line:
https://github.com/iann0036/aws.permissions.cloud/blob/e3e97441ed197acb976c4e2ed04e1c1b440a9624/assets/js/aws.permissions.cloud.js#L708-L717

`sdk_map['sdk_method_iam_mappings'][results[i]][0]` could be `undefined ` because the first element is shifted here:
https://github.com/iann0036/aws.permissions.cloud/blob/e3e97441ed197acb976c4e2ed04e1c1b440a9624/assets/js/aws.permissions.cloud.js#L877-L882

`Array#shift()` mutates the original array so it affects on usage of the array in other places.

This PR avoid the mutation to fix the TypeError.


### Errors

Searching `s3` on `/iam/s3` and `/api/s3` raise errors:
<img width="1510" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/13e82291-7df6-429b-a39f-63c56f6edeb3">

Searching `dynamodb ` on `/iam/s3` and `/api/s3` is fine:
<img width="1511" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/a71c40b8-e2a6-4ee1-bbdc-06b2c761d64b">

Searching `dynamodb` on `/iam/dynamodb` and `/api/dynamodb` raise errors:
<img width="1510" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/87d087b6-f119-4c47-996b-fa2b48d16cd6">


Searching `s3` on `/iam/dynamodb` and `/api/dynamodb` is fine:
<img width="1512" alt="image" src="https://github.com/iann0036/aws.permissions.cloud/assets/127635/974ba28d-7b3d-4177-97c8-0e5e77e224e7">

