### PR TITLE
Fix + character parsing in search query

### DIFF
--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -607,14 +607,9 @@ function expand_resource_type(service, resource_type) {
 }
 
 function getQueryVariable(variable) {
-    var query = window.location.search.substring(1);
-    var vars = query.split('&');
-    for (var i = 0; i < vars.length; i++) {
-        var pair = vars[i].split('=');
-        if (decodeURIComponent(pair[0]) == variable) {
-            return decodeURIComponent(pair[1]);
-        }
-    }
+    var params = new URLSearchParams(window.location.search);
+    var value = params.get(variable);
+    if (value !== null) return value;
     console.log('Query variable %s not found', variable);
 }
 


### PR DESCRIPTION
Use URLSearchParams to correctly parse `?s=query+with+plus`, for example when provided by Chrome browser. Otherwise, plus is not correctly interpreted as a space, and only %20 works well.

URLSearchParams has good support: https://caniuse.com/?search=urlsearchparams
Related: https://superuser.com/a/1691307

Same as https://github.com/iann0036/gcp.permissions.cloud/pull/4