### PR TITLE
fix: search shortcut does not work on some keyboard layouts

### DIFF
--- a/assets/js/aws.permissions.cloud.js
+++ b/assets/js/aws.permissions.cloud.js
@@ -681,14 +681,14 @@ async function processReferencePage() {
 
     $(window).on('keydown', function(e) {
         // Slash without any special keys to open search modal
-        if (e.keyCode === 191 && !e.shiftKey && !e.ctrlKey && !e.ctrlKey && !e.metaKey) {
+        if (e.key == '/') {
             if (!$('.navbar-search').hasClass('visible')) {
                 openSearchModal()
                 e.preventDefault();
             }
         }
         // Escape without any special keys to close search modal
-        if (e.keyCode === 27 && !e.shiftKey && !e.ctrlKey && !e.ctrlKey && !e.metaKey) {
+        if (e.key == 'Escape') {
             if ($('.navbar-search').hasClass('visible')) {
                 $('.navbar-search').removeClass('visible');
                 $('.backdrop').removeClass('show');


### PR DESCRIPTION
Search hotkey "/" does not work on some keyboard layouts like the spanish one as SHIFT + 7 needs to be pressed. SHIFT is explicitly negated in the event listener condition. 
As I saw that [keyCode ](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated, and the recommendation is to use [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key), I replaced it. 

I removed the negative condition on pressing shift and control keys as them prevented the shortcut to work, as well as I did not find the  scenario where them are necessary. 